### PR TITLE
Feature seasonal discount

### DIFF
--- a/site/components/gameInfo/GameInfo.stories.tsx
+++ b/site/components/gameInfo/GameInfo.stories.tsx
@@ -16,4 +16,6 @@ Default.args = {
   publisher: ["Valve"],
   releaseDate: "2000-10-31T15:00:00Z",
   imageUrl: "https://cdn.akamai.steamstatic.com/steam/apps/865360/header.jpg?t=1652179790",
+  seasonSaleCombo: "아주높음",
+  nextSeasonSaleKey: "autumn",
 } as GameInfoProps;

--- a/site/components/gameInfo/GameInfo.tsx
+++ b/site/components/gameInfo/GameInfo.tsx
@@ -3,6 +3,7 @@ import styled from "styled-components";
 import Colors from "../../styles/colors";
 import { GameDetails } from "./GameDetails";
 import { GameImage } from "./GameImage";
+import { SeasonSaleProbabilityPhrase } from "./SeasonSaleProbabilityPhrase";
 
 export interface GameInfoProps {
   name: string;
@@ -10,12 +11,17 @@ export interface GameInfoProps {
   publisher: string[];
   releaseDate: string;
   imageUrl: string;
+  seasonSaleCombo: string;
+  nextSeasonSaleKey: string;
 }
 
-export function GameInfo({ name, developer, publisher, releaseDate, imageUrl }: GameInfoProps) {
+export function GameInfo(props: GameInfoProps) {
+  const { name, developer, publisher, releaseDate, imageUrl, seasonSaleCombo, nextSeasonSaleKey } = props;
+
   return (
     <StyledRoot>
       <GameImage imageUrl={imageUrl} />
+      <SeasonSaleProbabilityPhrase seasonSaleCombo={seasonSaleCombo} nextSeasonSaleKey={nextSeasonSaleKey} />
       <GameDetails name={name} developer={developer} publisher={publisher} releaseDate={releaseDate} />
     </StyledRoot>
   );

--- a/site/components/gameInfo/SeasonSaleProbabilityPhrase.stories.tsx
+++ b/site/components/gameInfo/SeasonSaleProbabilityPhrase.stories.tsx
@@ -1,0 +1,16 @@
+import { Meta, Story } from "@storybook/react/types-6-0";
+
+import { SeasonSaleProbabilityPhrase, SeasonSaleProbabilityPhraseProps } from "./SeasonSaleProbabilityPhrase";
+
+export default {
+  title: "SeasonSaleProbabilityPhrase",
+  component: SeasonSaleProbabilityPhrase,
+} as Meta;
+
+const Template: Story<SeasonSaleProbabilityPhraseProps> = (args) => <SeasonSaleProbabilityPhrase {...args} />;
+
+export const Default = Template.bind({});
+Default.args = {
+  seasonSaleCombo: "아주높음",
+  nextSeasonSaleKey: "autumn",
+};

--- a/site/components/gameInfo/SeasonSaleProbabilityPhrase.tsx
+++ b/site/components/gameInfo/SeasonSaleProbabilityPhrase.tsx
@@ -34,7 +34,7 @@ export function SeasonSaleProbabilityPhrase({ seasonSaleCombo, nextSeasonSaleKey
   return <StyledProbabilityPhrase>{formattingPhrase()}</StyledProbabilityPhrase>;
 }
 
-const StyledProbabilityPhrase = styled.text`
+const StyledProbabilityPhrase = styled.div`
   margin-top: 2rem;
   margin-left: 1.6rem;
   font-weight: 400;

--- a/site/components/gameInfo/SeasonSaleProbabilityPhrase.tsx
+++ b/site/components/gameInfo/SeasonSaleProbabilityPhrase.tsx
@@ -1,0 +1,45 @@
+import styled from "styled-components";
+
+import Colors from "../../styles/colors";
+
+export interface SeasonSaleProbabilityPhraseProps {
+  seasonSaleCombo: string;
+  nextSeasonSaleKey: string;
+}
+
+interface ObjIndex {
+  [key: string]: string;
+}
+
+const season: ObjIndex = {
+  lunarNewYear: "설날",
+  summer: "여름",
+  autumn: "가을",
+  halloween: "할로윈",
+  winter: "겨울",
+};
+
+const probability: ObjIndex = {
+  아주높음: "아주 높아",
+  높음: "높아",
+  보통: "보통이에",
+  낮음: "낮아",
+};
+
+export function SeasonSaleProbabilityPhrase({ seasonSaleCombo, nextSeasonSaleKey }: SeasonSaleProbabilityPhraseProps) {
+  const formattingPhrase = () => {
+    return `다가오는 ${season[nextSeasonSaleKey]} 할인에 참여할 확률이 ${probability[seasonSaleCombo]}요!`;
+  };
+
+  return <StyledProbabilityPhrase>{formattingPhrase()}</StyledProbabilityPhrase>;
+}
+
+const StyledProbabilityPhrase = styled.text`
+  margin-top: 2rem;
+  margin-left: 1.6rem;
+  font-weight: 400;
+  font-size: 1.2rem;
+  line-height: 1.8rem;
+  letter-spacing: -0.02em;
+  color: ${Colors.Green};
+`;

--- a/site/components/seasonalSale/Figure.tsx
+++ b/site/components/seasonalSale/Figure.tsx
@@ -11,8 +11,18 @@ export interface FigureProps {
 export function Figure({ activation, figureName }: FigureProps) {
   return (
     <StyledRoot>
-      {activation && <MdFastRewind size={14} color={Colors.Green} />}
-      <FigureCircle activation={activation}></FigureCircle>
+      {activation ? (
+        <>
+          <MdFastRewind size={14} color={Colors.Green} />
+          <CircleWrapper>
+            <OutCircle></OutCircle>
+            <Circle activation={activation}></Circle>
+          </CircleWrapper>
+        </>
+      ) : (
+        <Circle activation={activation}></Circle>
+      )}
+
       <FigureName activation={activation}>{figureName}</FigureName>
     </StyledRoot>
   );
@@ -29,7 +39,22 @@ const StyledRoot = styled.div`
   }
 `;
 
-const FigureCircle = styled.div<{ activation: boolean }>`
+const CircleWrapper = styled.div`
+  position: relative;
+`;
+
+const OutCircle = styled.div`
+  position: absolute;
+  left: -0.2rem;
+  top: 0.2rem;
+  width: 1.4rem;
+  height: 1.4rem;
+  border-radius: 5rem;
+  background-color: ${Colors.Green};
+  opacity: 50%;
+`;
+
+const Circle = styled.div<{ activation: boolean }>`
   width: 1rem;
   height: 1rem;
   border-radius: 5rem;
@@ -39,7 +64,6 @@ const FigureCircle = styled.div<{ activation: boolean }>`
     activation &&
     css`
       margin-top: 0.4rem;
-      box-shadow: 0 0 0.2rem 0.2rem rgba(206, 242, 130, 0.5);
       background-color: ${Colors.Green};
     `};
 `;
@@ -49,5 +73,5 @@ const FigureName = styled.div<{ activation: boolean }>`
   font-size: 1.3rem;
   letter-spacing: 0.02rem;
   color: ${({ activation }) => (activation ? Colors.Green : Colors.Disabled)};
-  margin-top: 0.4rem;
+  margin-top: 0.6rem;
 `;

--- a/site/components/seasonalSale/Figure.tsx
+++ b/site/components/seasonalSale/Figure.tsx
@@ -1,0 +1,53 @@
+import { MdFastRewind } from "react-icons/md";
+import styled, { css } from "styled-components";
+
+import Colors from "../../styles/colors";
+
+export interface FigureProps {
+  activation: boolean;
+  figureName: string;
+}
+
+export function Figure({ activation, figureName }: FigureProps) {
+  return (
+    <StyledRoot>
+      {activation && <MdFastRewind size={14} color={Colors.Green} />}
+      <FigureCircle activation={activation}></FigureCircle>
+      <FigureName activation={activation}>{figureName}</FigureName>
+    </StyledRoot>
+  );
+}
+
+const StyledRoot = styled.div`
+  height: 4.9rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: end;
+  & > svg {
+    transform: rotate(-90deg);
+  }
+`;
+
+const FigureCircle = styled.div<{ activation: boolean }>`
+  width: 1rem;
+  height: 1rem;
+  border-radius: 5rem;
+  background-color: ${Colors.Disabled};
+
+  ${({ activation }) =>
+    activation &&
+    css`
+      margin-top: 0.4rem;
+      box-shadow: 0 0 0.2rem 0.2rem rgba(206, 242, 130, 0.5);
+      background-color: ${Colors.Green};
+    `};
+`;
+
+const FigureName = styled.div<{ activation: boolean }>`
+  font-weight: 400;
+  font-size: 1.3rem;
+  letter-spacing: 0.02rem;
+  color: ${({ activation }) => (activation ? Colors.Green : Colors.Disabled)};
+  margin-top: 0.4rem;
+`;

--- a/site/components/seasonalSale/ParticipationProbability.stories.tsx
+++ b/site/components/seasonalSale/ParticipationProbability.stories.tsx
@@ -1,0 +1,19 @@
+import { Meta, Story } from "@storybook/react/types-6-0";
+
+import { ParticipationProbability, ParticipationProbabilityProps } from "./ParticipationProbability";
+
+export default {
+  title: "ParticipationProbability",
+  component: ParticipationProbability,
+} as Meta;
+
+const Template: Story<ParticipationProbabilityProps> = (args) => {
+  return <ParticipationProbability {...args} />;
+};
+
+export const Basic = Template.bind({});
+Basic.args = {
+  figureNameList: ["낮음", "보통", "높음", "아주높음"],
+  seasonSaleCombo: "아주높음",
+  nextSeasonName: "가을 세일 (Autumn Sale)",
+} as ParticipationProbabilityProps;

--- a/site/components/seasonalSale/ParticipationProbability.tsx
+++ b/site/components/seasonalSale/ParticipationProbability.tsx
@@ -25,9 +25,9 @@ export function ParticipationProbability({
           <Figure key={index} activation={figureName === seasonSaleCombo} figureName={figureName} />
         ))}
       </FigureWrapper>
-      <FigureLine>
+      <LineWrapper>
         <Line></Line>
-      </FigureLine>
+      </LineWrapper>
     </StyledRoot>
   );
 }
@@ -75,7 +75,7 @@ const FigureWrapper = styled.section`
   z-index: 3;
 `;
 
-const FigureLine = styled.div`
+const LineWrapper = styled.div`
   position: absolute;
   bottom: 4rem;
   width: 100%;

--- a/site/components/seasonalSale/ParticipationProbability.tsx
+++ b/site/components/seasonalSale/ParticipationProbability.tsx
@@ -1,0 +1,89 @@
+import styled from "styled-components";
+
+import Colors from "../../styles/colors";
+import { Figure } from "./Figure";
+
+export interface ParticipationProbabilityProps {
+  figureNameList: string[];
+  seasonSaleCombo: string;
+  nextSeasonName: string;
+}
+
+export function ParticipationProbability({
+  figureNameList,
+  seasonSaleCombo,
+  nextSeasonName,
+}: ParticipationProbabilityProps) {
+  return (
+    <StyledRoot>
+      <TitleWrapper>
+        <Label>예정</Label>
+        <Title>{nextSeasonName}</Title>
+      </TitleWrapper>
+      <FigureWrapper>
+        {figureNameList.map((figureName, index) => (
+          <Figure key={index} activation={figureName === seasonSaleCombo} figureName={figureName} />
+        ))}
+      </FigureWrapper>
+      <FigureLine>
+        <Line></Line>
+      </FigureLine>
+    </StyledRoot>
+  );
+}
+
+const StyledRoot = styled.article`
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  height: 13rem;
+  background-color: ${Colors.ContentBackground};
+`;
+
+const TitleWrapper = styled.section`
+  display: flex;
+  justify-content: center;
+  margin: 2rem 0 2.2rem;
+`;
+
+const Label = styled.aside`
+  width: 3.4rem;
+  height: 2.1rem;
+  font-weight: 400;
+  font-size: 1.2rem;
+  line-height: 2.1rem;
+  letter-spacing: -0.02em;
+  color: ${Colors.Blue};
+  text-align: center;
+  margin-right: 1rem;
+  border: 1px solid ${Colors.Blue};
+`;
+
+const Title = styled.h4`
+  font-weight: 700;
+  font-size: 1.4rem;
+  line-height: 140%;
+  letter-spacing: -0.02em;
+  color: ${Colors.White};
+`;
+
+const FigureWrapper = styled.section`
+  padding: 0 2.7rem;
+  display: flex;
+  justify-content: space-between;
+  z-index: 3;
+`;
+
+const FigureLine = styled.div`
+  position: absolute;
+  bottom: 4rem;
+  width: 100%;
+`;
+
+const Line = styled.div`
+  height: 1px;
+  margin: 0 4.7rem 0 4rem;
+  background-color: ${Colors.Disabled};
+  z-index: 1;
+`;

--- a/site/components/seasonalSale/ParticipationProbability.tsx
+++ b/site/components/seasonalSale/ParticipationProbability.tsx
@@ -69,7 +69,7 @@ const Title = styled.h4`
 `;
 
 const FigureWrapper = styled.section`
-  padding: 0 2.7rem;
+  padding: 0 1rem 0 2.1rem;
   display: flex;
   justify-content: space-between;
   z-index: 3;
@@ -77,13 +77,13 @@ const FigureWrapper = styled.section`
 
 const LineWrapper = styled.div`
   position: absolute;
-  bottom: 4rem;
+  bottom: 4.1rem;
   width: 100%;
 `;
 
 const Line = styled.div`
   height: 1px;
-  margin: 0 4.7rem 0 4rem;
+  margin: 0 3rem;
   background-color: ${Colors.Disabled};
   z-index: 1;
 `;

--- a/site/components/seasonalSale/ParticipationProbability.tsx
+++ b/site/components/seasonalSale/ParticipationProbability.tsx
@@ -36,7 +36,7 @@ const StyledRoot = styled.article`
   position: relative;
   display: flex;
   flex-direction: column;
-  width: 100%;
+  margin: 0 1.6rem;
   height: 13rem;
   background-color: ${Colors.ContentBackground};
 `;

--- a/site/components/seasonalSale/SeasonSaleProbability.stories.tsx
+++ b/site/components/seasonalSale/SeasonSaleProbability.stories.tsx
@@ -1,0 +1,18 @@
+import { Meta, Story } from "@storybook/react/types-6-0";
+
+import { SeasonSaleProbability, SeasonSaleProbabilityProps } from "./SeasonSaleProbability";
+
+export default {
+  title: "SeasonSaleProbability",
+  component: SeasonSaleProbability,
+} as Meta;
+
+const Template: Story<SeasonSaleProbabilityProps> = (args) => {
+  return <SeasonSaleProbability {...args} />;
+};
+
+export const Default = Template.bind({});
+Default.args = {
+  seasonSaleCombo: "아주높음",
+  nextSeasonName: "가을 세일 (Autumn Sale)",
+} as SeasonSaleProbabilityProps;

--- a/site/components/seasonalSale/SeasonSaleProbability.stories.tsx
+++ b/site/components/seasonalSale/SeasonSaleProbability.stories.tsx
@@ -14,5 +14,6 @@ const Template: Story<SeasonSaleProbabilityProps> = (args) => {
 export const Default = Template.bind({});
 Default.args = {
   seasonSaleCombo: "아주높음",
-  nextSeasonName: "가을 세일 (Autumn Sale)",
+  nextSeasonSaleKey: "autumn",
+  nextSeasonSaleName: "Autumn Sale",
 } as SeasonSaleProbabilityProps;

--- a/site/components/seasonalSale/SeasonSaleProbability.tsx
+++ b/site/components/seasonalSale/SeasonSaleProbability.tsx
@@ -1,0 +1,26 @@
+import { CommonAccordion } from "../common/CommonAccordion";
+import { ParticipationProbability } from "./ParticipationProbability";
+
+export interface SeasonSaleProbabilityProps {
+  seasonSaleCombo: string;
+  nextSeasonName: string;
+}
+
+export function SeasonSaleProbability({ seasonSaleCombo, nextSeasonName }: SeasonSaleProbabilityProps) {
+  const commonAccordionProps = {
+    summary: "다가오는 계절 할인에 참여할 확률",
+    description: "STEAM에서 진행하는 계절 할인은 설날, 여름, 가을, 할로윈, 겨울로 총 5번의 계절 할인이 있어요. ",
+  };
+  const figureNameList = ["낮음", "보통", "높음", "아주높음"];
+
+  return (
+    <>
+      <CommonAccordion {...commonAccordionProps} />
+      <ParticipationProbability
+        figureNameList={figureNameList}
+        seasonSaleCombo={seasonSaleCombo}
+        nextSeasonName={nextSeasonName}
+      />
+    </>
+  );
+}

--- a/site/components/seasonalSale/SeasonSaleProbability.tsx
+++ b/site/components/seasonalSale/SeasonSaleProbability.tsx
@@ -3,15 +3,35 @@ import { ParticipationProbability } from "./ParticipationProbability";
 
 export interface SeasonSaleProbabilityProps {
   seasonSaleCombo: string;
-  nextSeasonName: string;
+  nextSeasonSaleName: string;
+  nextSeasonSaleKey: string;
 }
 
-export function SeasonSaleProbability({ seasonSaleCombo, nextSeasonName }: SeasonSaleProbabilityProps) {
+interface SeasonIndex {
+  [key: string]: string;
+}
+
+const Season: SeasonIndex = {
+  lunarNewYear: "설날",
+  summer: "여름",
+  autumn: "가을",
+  halloween: "할로윈",
+  winter: "겨울",
+};
+
+export function SeasonSaleProbability({
+  seasonSaleCombo,
+  nextSeasonSaleName,
+  nextSeasonSaleKey,
+}: SeasonSaleProbabilityProps) {
   const commonAccordionProps = {
     summary: "다가오는 계절 할인에 참여할 확률",
     description: "STEAM에서 진행하는 계절 할인은 설날, 여름, 가을, 할로윈, 겨울로 총 5번의 계절 할인이 있어요. ",
   };
   const figureNameList = ["낮음", "보통", "높음", "아주높음"];
+  const nextSeasonName = () => {
+    return `${Season[nextSeasonSaleKey]} 세일 (${nextSeasonSaleName})`;
+  };
 
   return (
     <>
@@ -19,7 +39,7 @@ export function SeasonSaleProbability({ seasonSaleCombo, nextSeasonName }: Seaso
       <ParticipationProbability
         figureNameList={figureNameList}
         seasonSaleCombo={seasonSaleCombo}
-        nextSeasonName={nextSeasonName}
+        nextSeasonName={nextSeasonName()}
       />
     </>
   );

--- a/site/styles/colors.ts
+++ b/site/styles/colors.ts
@@ -6,6 +6,7 @@ const enum Colors {
   Green = "#C6F06B",
   LightGray = "#A7A9C3",
   TextBackground = "#2A2D65",
+  ContentBackground = "#131533",
   White = "#FFFFFF",
 }
 


### PR DESCRIPTION
- season sale probability phrase 컴포넌트 생성 및 GUI 적용
- participaation probability 컴포넌트 생성 및 GUI 적용
- 두개 컴포넌트 모두 백엔드에서 가져온 데이터를 조금 다르게 가공해서 화면에 표시해주어야 하거든요. 근데 문제는 이 두 컴포넌트가 약간 다르게 사용을 하고 있어서 api 를 부르는 부분 즉, gateway에서 문장을 만들어 보내기도 좀 그렇다는 것입니다. 애초에 거기에서는 데이터를 사용하는 모든 곳을 고려해야하고 세부적인 부분은 고려하지 않는게 맞다고 생각했습니다. 그리고 각 컴포넌트 단은 해당 화면을 책임져야하니까 세부적인 부분을 고려해야한다고 생각해서 문장 만드는 부분이 중복되게 되었구요. 중복이 일단 두번이니 내버려 두긴햇는데 혹시 더 좋은 의견, 방법이 있다면 말해주세요~